### PR TITLE
Restore "+" launcher button in filebrowser sidebar

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -8,6 +8,15 @@
       "selector": "body"
     }
   ],
+  "jupyter.lab.toolbars": {
+    "FileBrowser": [
+      {
+        "name": "new-launcher",
+        "command": "launcher:create",
+        "rank": 1
+      }
+    ]
+  },
   "properties": {
     "categories": {
       "title": "Launcher categories in displayed order",


### PR DESCRIPTION
Restore the missing new launcher button in the file browser. 

Fixes #64 

@fcollonval Can you please review and merge this small fix?